### PR TITLE
List requirement of URI version 1.61

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -23,7 +23,7 @@ WriteMakefile(
 		Test::LWP::UserAgent	=> 0,
 		Text::Trim		=> 0,
 		Time::HiRes		=> 0,
-		URI			=> 0,
+		URI			=> 1.61,
 		List::BinarySearch	=> 0,
 	},
 	META_MERGE => {


### PR DESCRIPTION
We use "has_recognized_scheme" from URI, which was added in 1.61. Add this as a minimum version requirement.